### PR TITLE
gif cache fix

### DIFF
--- a/app/controllers/api/v1/gifs_controller.rb
+++ b/app/controllers/api/v1/gifs_controller.rb
@@ -1,6 +1,34 @@
 class Api::V1::GifsController < ApplicationController
   def index
+    if (cache_empty? || params['location'] != check_location)
       gifs = GiphyDaysWeatherPresenter.new(params['location'])
       render json: GifsSerializer.new(gifs)
+      cache_result(:gifs, GifsSerializer.new(gifs))
+      cache_location(:gif_location, params['location'])
+    else
+      render json: read_cache
+    end
   end
+end
+
+private
+
+def cache_result(gifs, serializer)
+  Rails.cache.write(gifs, serializer, expires_in: 1.day)
+end
+
+def cache_empty?
+  Rails.cache.read(:gifs).nil?
+end
+
+def read_cache
+  Rails.cache.read(:gifs)
+end
+
+def cache_location(gif_location, location)
+  Rails.cache.write(gif_location, location, expires_in: 1.day)
+end
+
+def check_location
+  Rails.cache.read(:gif_location)
 end

--- a/app/facades/days_weather_facade.rb
+++ b/app/facades/days_weather_facade.rb
@@ -1,8 +1,9 @@
 class DaysWeatherFacade
   def self.get_daily_weather(lat, lon)
-    if cache_empty_daily?
+    if cache_empty_daily? || lat_lon_changed != "#{lat}, #{lon}"
       data = ForecastService.new(lat, lon).parse_response
       cache_result_daily(:daily, DaysWeather.make_forecast_array(data))
+      cache_lat_lon(:lat_lon, "#{lat}, #{lon}")
       DaysWeather.make_forecast_array(data)
     else
       read_cache_daily
@@ -22,4 +23,12 @@ end
 
 def read_cache_daily
   Rails.cache.read(:daily)
+end
+
+def cache_lat_lon(lat_lon, lat_lon_string)
+  Rails.cache.write(lat_lon, lat_lon_string)
+end
+
+def lat_lon_changed
+  Rails.cache.read(:lat_lon)
 end


### PR DESCRIPTION
Adds a check to the lat and lon on the days weather facade that will now allow the gifs endpoint to update as the location changes. This had to be done there as the gifs endpoint does not return a location to be cached due to my own poor planning. In the future may want to pass location though to the end.